### PR TITLE
use tf-official-apps cross-linked flist in Terraform HCL files 

### DIFF
--- a/terraform/leader/main.tf
+++ b/terraform/leader/main.tf
@@ -36,7 +36,7 @@ resource "grid_deployment" "d0" {
 
   vms {
     name = "caprover"
-    flist = "https://hub.grid.tf/samehabouelsaad.3bot/tf-caprover-main-a4f186da8d.flist"
+    flist = "https://hub.grid.tf/tf-official-apps/tf-caprover-main.flist"
     # modify the cores according to your needs
     cpu = 4
     publicip = true

--- a/terraform/worker/main.tf
+++ b/terraform/worker/main.tf
@@ -30,7 +30,7 @@ resource "grid_deployment" "d2" {
 
   vms {
     name = "caprover"
-    flist = "https://hub.grid.tf/samehabouelsaad.3bot/abouelsaad-caprover-tf_10.0.1_v1.0.flist"
+    flist = "https://hub.grid.tf/tf-official-apps/tf-caprover-main.flist"
     # modify the cores according to your needs
     cpu = 2
     publicip = true


### PR DESCRIPTION
use symlinked flist `https://hub.grid.tf/tf-official-apps/tf-caprover-main.flist` in terraform HCL files 