### PR TITLE
support overriding default password

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,22 +47,25 @@ git clone https://github.com/freeflowuniverse/freeflow_caprover.git
 
   ```bash
   cd freeflow_caprover/terraform/leader/
+  export MNEMONICS="<mnemonics words>"
+  export NETWORK="<network>" # dev or test
   vim main.tf
   ```
 
-  - In `provider` Block, update the `twin_id` and add your `mnemonics`.
   - In `resource` Block, update the disks size, memory size, and cores number to fit your needs or leave as it is for testing.
   - In the `PUBLIC_KEY` env var value put your ssh public key .
   - In the `CAPROVER_ROOT_DOMAIN` env var value put your root domain, this is optional and you can add it later from the dashboard put it will save you the extra step and allow you to access your dashboard using your domain name directly after the deployment.
+  - In the `DEFAULT_PASSWORD` env var value put a password to be used for login to captain dashboard or leave it as it is to generate random password.
 
 - save the file, and execute the following commands:
 
   ```bash
-  terraform init
-  terraform apply -parallelism=1
+  terraform init && terraform apply -parallelism=1
   ```
 
 - wait till you see `apply complete`, and note the VM public ip in the final output.
+
+- not the tf output of `caprover_default_password`. you will need this password to login to the captain dashboard later.
 
 - verify the status of the VM
 
@@ -217,7 +220,7 @@ To confirm, go to https://mxtoolbox.com/DNSLookup.aspx and enter `somethingrando
 
 skip this step if you provided your root domain in the TerraFrom configuration file
 
-Once the CapRover is initialized, you can visit `http://[IP_OF_YOUR_SERVER]:3000` in your browser and login to CapRover using the default password `captain42`. You can change your password later.
+Once the CapRover is initialized, you can visit `http://[IP_OF_YOUR_SERVER]:3000` in your browser and login to CapRover using the password from tf output noted in previous step. also you can change your password later.
 
 In the UI enter you root domain and press Update Domain button.
 

--- a/docker/scripts/caprover_leader.sh
+++ b/docker/scripts/caprover_leader.sh
@@ -18,7 +18,8 @@ if [[ ! -z "${CAPROVER_ROOT_DOMAIN}" ]]; then
 
 fi
 
-while ! docker run -p 80:80 -p 443:443 -p 3000:3000 -v /var/run/docker.sock:/var/run/docker.sock -v /captain:/captain $CAPTAIN_IMAGE:$CAPTAIN_IMAGE_VERSION; do
+[ -z "$DEFAULT_PASSWORD" ] && DEFAULT_PASSWORD="captain42"
+while ! docker run -e DEFAULT_PASSWORD='${DEFAULT_PASSWORD}' -p 80:80 -p 443:443 -p 3000:3000 -v /var/run/docker.sock:/var/run/docker.sock -v /captain:/captain $CAPTAIN_IMAGE:$CAPTAIN_IMAGE_VERSION; do
     sleep 2
 done
 

--- a/terraform/leader/main.tf
+++ b/terraform/leader/main.tf
@@ -7,20 +7,41 @@ terraform {
 }
 
 provider "grid" {
-    mnemonics = ""
 }
-
+resource "random_string" "password" {
+  length           = 16
+  special          = true
+  override_special = "_%@"
+}
+resource "grid_scheduler" "sched" {
+  # a machine for the first server instance
+  requests {
+    name = "vm0"
+    cru = 4
+    sru = 100
+    mru = 8192
+  }
+}
 resource "grid_network" "net0" {
-    nodes = [4]
+    # uncomment next line and comment the line after if you need to not use grid_scheduler
+    # nodes = [4]
+    nodes = distinct([
+      grid_scheduler.sched.nodes["vm0"],
+    ])
     ip_range = "10.1.0.0/16"
     name = "network"
     description = "newer network"
+    # set add_wg_access to true to allow access through wireguard
+    add_wg_access = false
 }
 
 resource "grid_deployment" "d0" {
-  node = 4
   network_name = grid_network.net0.name
-  ip_range = grid_network.net0.nodes_ip_range["4"]
+  # uncomment next two lines and comment the two line after if you need to not use grid_scheduler
+  # node = 4
+  # ip_range = grid_network.net0.nodes_ip_range["4"]
+  node = grid_scheduler.sched.nodes["vm0"]
+  ip_range = lookup(grid_network.net0.nodes_ip_range, grid_scheduler.sched.nodes["vm0"], "")
   disks {
     name        = "data0"
     # will hold images, volumes etc. modify the size according to your needs
@@ -39,9 +60,11 @@ resource "grid_deployment" "d0" {
     flist = "https://hub.grid.tf/tf-official-apps/tf-caprover-main.flist"
     # modify the cores according to your needs
     cpu = 4
-    publicip = true
     # modify the memory according to your needs
     memory = 8192
+    publicip = true
+    # set planetary to true to allow access through yggdrasil network
+    planetary = false
     entrypoint = "/sbin/zinit init"
     mounts {
       disk_name   = "data0"
@@ -51,22 +74,19 @@ resource "grid_deployment" "d0" {
       disk_name   = "data1"
       mount_point = "/captain"
     }
-    env_vars {
-      key = "PUBLIC_KEY"
-      value = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC9MI7fh4xEOOEKL7PvLvXmSeRWesToj6E26bbDASvlZnyzlSKFLuYRpnVjkr8JcuWKZP6RQn8+2aRs6Owyx7Tx+9kmEh7WI5fol0JNDn1D0gjp4XtGnqnON7d0d5oFI+EjQQwgCZwvg0PnV/2DYoH4GJ6KPCclPz4a6eXrblCLA2CHTzghDgyj2x5B4vB3rtoI/GAYYNqxB7REngOG6hct8vdtSndeY1sxuRoBnophf7MPHklRQ6EG2GxQVzAOsBgGHWSJPsXQkxbs8am0C9uEDL+BJuSyFbc/fSRKptU1UmS18kdEjRgGNoQD7D+Maxh1EbmudYqKW92TVgdxXWTQv1b1+3dG5+9g+hIWkbKZCBcfMe4nA5H7qerLvoFWLl6dKhayt1xx5mv8XhXCpEC22/XHxhRBHBaWwSSI+QPOCvs4cdrn4sQU+EXsy7+T7FIXPeWiC2jhFd6j8WIHAv6/rRPsiwV1dobzZOrCxTOnrqPB+756t7ANxuktsVlAZaM= sameh@sameh-inspiron-3576"
-    }
-    # SWM_NODE_MODE env var is required, should be "leader" or "worker"
-    # leader: will run sshd, containerd, dockerd as zinit services plus caprover service in leader mode which start caprover, lets encrypt, nginx containers.
-    # worker: will run sshd, containerd, dockerd as zinit services plus caprover service in orker mode which only join the swarm cluster. check the wroker terrafrom file example.
-    env_vars {
-      key = "SWM_NODE_MODE"
-      value = "leader"
-    }
-    # CAPROVER_ROOT_DOMAIN is optional env var, by providing it you can access the captain dashboard after vm initilization by visiting http://captain.your-root-domain
-    # otherwise you will have to add the root domain manually from the captain dashboard by visiting http://{publicip}:3000 to access the dashboard
-    env_vars {
-      key = "CAPROVER_ROOT_DOMAIN"
-      value = "roverapps.grid.tf"
+    env_vars = {
+      PUBLIC_KEY = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC9MI7fh4xEOOEKL7PvLvXmSeRWesToj6E26bbDASvlZnyzlSKFLuYRpnVjkr8JcuWKZP6RQn8+2aRs6Owyx7Tx+9kmEh7WI5fol0JNDn1D0gjp4XtGnqnON7d0d5oFI+EjQQwgCZwvg0PnV/2DYoH4GJ6KPCclPz4a6eXrblCLA2CHTzghDgyj2x5B4vB3rtoI/GAYYNqxB7REngOG6hct8vdtSndeY1sxuRoBnophf7MPHklRQ6EG2GxQVzAOsBgGHWSJPsXQkxbs8am0C9uEDL+BJuSyFbc/fSRKptU1UmS18kdEjRgGNoQD7D+Maxh1EbmudYqKW92TVgdxXWTQv1b1+3dG5+9g+hIWkbKZCBcfMe4nA5H7qerLvoFWLl6dKhayt1xx5mv8XhXCpEC22/XHxhRBHBaWwSSI+QPOCvs4cdrn4sQU+EXsy7+T7FIXPeWiC2jhFd6j8WIHAv6/rRPsiwV1dobzZOrCxTOnrqPB+756t7ANxuktsVlAZaM= sameh@sameh-inspiron-3576"
+      # SWM_NODE_MODE env var is required, should be "leader" or "worker"
+      # leader: will run sshd, containerd, dockerd as zinit services plus caprover service in leader mode which start caprover, lets encrypt, nginx containers.
+      # worker: will run sshd, containerd, dockerd as zinit services plus caprover service in orker mode which only join the swarm cluster. check the wroker terrafrom file example.
+      SWM_NODE_MODE = "leader"
+      # CAPROVER_ROOT_DOMAIN is optional env var, by providing it you can access the captain dashboard after vm initilization by visiting http://captain.your-root-domain
+      # otherwise you will have to add the root domain manually from the captain dashboard by visiting http://{publicip}:3000 to access the dashboard
+      CAPROVER_ROOT_DOMAIN = "samehabouelsaad.grid.tf"
+      # DEFAULT_PASSWORD is optional env var, it allow you to set custom initial password.
+      # in this example we use The "random" provider, but you can use also any custom string, in this case please use strong password.
+      # by not providing this env var, or leaving it empty CapRover will use `captain42` as its default password (not recommended!).
+      DEFAULT_PASSWORD = random_string.password.result
     }
   }
 }
@@ -82,4 +102,7 @@ output "vm_ip" {
 }
 output "vm_public_ip" {
     value = grid_deployment.d0.vms[0].computedip
+}
+output "caprover_default_password" {
+    value = random_string.password.result
 }


### PR DESCRIPTION
 - updating the use of env vars to match the updated terraform provider plugin instructions.
- support overriding the default password, we use the `random` provider to generate a random password. alternatively, you can choose the initial password yourself.
- updating the docs.
- use the dynamic scheduler resource.

this should be fix issues #5 and #7